### PR TITLE
Update cloudjack.py

### DIFF
--- a/cloudjack.py
+++ b/cloudjack.py
@@ -89,7 +89,7 @@ o888     88  888   ooooooo  oooo  oooo   ooooo888   888   ooooooo    ooooooo   8
     results = []
 
     # Enumerate and iterate through all Route53 hosted zone ID's
-    for hosted_zone in sorted(route53.list_hosted_zones()['HostedZones']):
+    for hosted_zone in route53.list_hosted_zones()['HostedZones']:
 
         # Parse ZoneID result
         zoneid = hosted_zone['Id'].split("/")[2]


### PR DESCRIPTION
`sorted()` breaks the script:

```
Traceback (most recent call last):
  File "/private/tmp/cloudjack/cloudjack/cloudjack.py", line 183, in <module>
    main()
  File "/private/tmp/cloudjack/cloudjack/cloudjack.py", line 90, in main
    print(route53.list_hosted_zones()['HostedZones'].sort())
TypeError: '<' not supported between instances of 'dict' and 'dict'
```